### PR TITLE
Support JSON output

### DIFF
--- a/IPerfAutomate.psm1
+++ b/IPerfAutomate.psm1
@@ -428,7 +428,10 @@ function Start-IPerfMonitorTest {
 					$true
 				}
 			})]
-		[string]$FileSize
+		[string]$FileSize,
+
+		[Parameter()]
+		[switch]$OutputJSON
 	)
 	begin {
 		$ErrorActionPreference = 'Stop'
@@ -476,6 +479,9 @@ function Start-IPerfMonitorTest {
 				$iPerfArgs = ('-c {0} -w {1}' -f $_, $WindowSize)
 				if ($PSBoundParameters.ContainsKey('FileSize')) {
 					$iPerfArgs += " -F `"$localTestFilePath`""
+				}
+				if ($OutputJSON) {
+					$iPerfArgs += ' -J '
 				}
 				InvokeIperf -ComputerName $FromServerName -Arguments $iPerfArgs
 			}


### PR DESCRIPTION
Howdy Adam,
I made a very trivial change that allows your module to output JSON (using iPerf's -J switch) instead of the default text blob.

The JSON includes all of the info from the default text output and then some.  Using the JSON output would allow us to easily manipulate the output with PowerShell.

I'm interested in just the summary information, for example: 

```
$Results = Start-IPerfMonitorTest -FromServerName $env:COMPUTERNAME -ToServerName remote-computer-name -OutputJSON | ConvertFrom-Json
$Results | Select-Object @{N='Time'; E={([datetime]$PSItem.start.timestamp.time).ToLocalTime()}}, @{N='Sent'; E={"{0:N2} Mbit/s" -f ($PSItem.end.sum_sent.bits_per_second / 1MB) }}, @{N='Received'; E={"{0:N2} Mbit/s" -f ($PSItem.end.sum_received.bits_per_second / 1MB) }}

Time                Sent         Received
----                ----         --------
3/4/2020 1:29:00 PM 46.69 Mbit/s 46.69 Mbit/s
```

Of course this is just the tip of the iceberg with the JSON data. 

I hope you find this useful.  Your blog posts have been very helpful to me as I'm learning more about PowerShell.  Thanks for all you do.